### PR TITLE
h815/h815_usu: reverted pref network to STOCK

### DIFF
--- a/lineage_h815.mk
+++ b/lineage_h815.mk
@@ -41,8 +41,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     rild.libargs=-d /dev/smd0 \
     ril.subscription.types=NV,RUIM \
     ro.telephony.call_ring.multiple=0 \
-    ro.telephony.default_network=12 \
-    telephony.lteOnCdmaDevice=0 \
-    telephony.lteOnGsmDevice=1
+    ro.telephony.default_network=9 \
+    telephony.lteOnCdmaDevice=0
 
 DEBUG_ME += lineage_h815.mk

--- a/lineage_h815_usu.mk
+++ b/lineage_h815_usu.mk
@@ -41,8 +41,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     rild.libargs=-d /dev/smd0 \
     ril.subscription.types=NV,RUIM \
     ro.telephony.call_ring.multiple=0 \
-    ro.telephony.default_network=12 \
-    telephony.lteOnCdmaDevice=0 \
-    telephony.lteOnGsmDevice=1
+    ro.telephony.default_network=9 \
+    telephony.lteOnCdmaDevice=0
 
 DEBUG_ME += lineage_h815_usu.mk


### PR DESCRIPTION
that was BS in any case as 12 means LTE/WCDMA only :
https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r1/telephony/java/com/android/internal/telephony/RILConstants.java#152

9 means LTE, GSM/WCDMA and so ensure GSM phones will still going
strong when no LTE/WCDMA is available

This also removes the stupid telephony.lteOnGsmDevice setting

Change-Id: I875596642af41fdd45cfec761d0b3bf1ff55261c